### PR TITLE
Fix GCS upload failure for large .xlsx files by setting predefinedAcl to bucketLevel

### DIFF
--- a/ccc_biospecimen_metrics_api.R
+++ b/ccc_biospecimen_metrics_api.R
@@ -106,7 +106,7 @@ function(report, testing = FALSE) {
   # Loop through CSV and PDF files, write them to GCP Cloud Storage, and print their names
   filelist <- list.files(pattern = "*.csv$|*.xlsx$|*.pdf$")
   uploaded_files <- lapply(filelist, function(x) {
-    gcs_upload(x, bucket = bucket, name = x)
+    gcs_upload(x, bucket = bucket, name = x, predefinedAcl = "bucketLevel")
     print(paste("Uploaded file:", x))
     x # Return the file name for further processing if needed
   })


### PR DESCRIPTION
**Issue**
The `ccc_biospecimen_metrics_api.R` was failing when uploading generated `.xlsx` files for the `Weekly Biospecimen CSV Outputs.R` script (Cloud Scheduler job: `ccc-weekly-biospecimen-metrics-csvs`) to the Google Cloud Storage bucket with the following error:

```
<simpleError in value[[3L]](cond): Must supply either retry_object or all of upload_url, file and type>
```

This occurred only for larger `.xlsx` output files while smaller files from other Cloud Scheduler jobs uploaded successfully.

**Root Cause**
The `.xlsx` file size is large enough to trigger `googleCloudStorageR`’s resumable upload process, which uploads files in multiple chunks and attempts to retry if an upload is interrupted.

The `ccc_weekly_metrics_report` bucket is configured with Uniform bucket-level access, meaning all uploads must use bucket-level permissions and object-level ACLs are not supported.

During upload retries, the request did not explicitly specify the required bucket-level ACL. As a result, the resumed upload did not match the original upload session, causing the retry process to fail and produce an error.

This behavior is consistent with known issues reported in the `googleCloudStorageR` repository, where resumable uploads can fail during retry for larger files:
- General resumable upload failures and retry issues: https://github.com/cloudyr/googleCloudStorageR/issues/122
- Specific workaround requiring `predefinedAcl = "bucketLevel"`: https://github.com/cloudyr/googleCloudStorageR/issues/124

**Fix**
Updated the GCS upload call to explicitly use bucket-level ACLs. This aligns the upload request with the bucket’s Uniform bucket-level access configuration and resolves failures in the resumable upload retry path.