### PR TITLE
Fix tinytex repo mirror

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update \
 
 # Install tinytex
 RUN Rscript -e 'devtools::install_version("tinytex", version="0.59", repos="https://cloud.r-project.org")' && \
-    Rscript -e 'tinytex::install_tinytex(version = "2026.04", bundle = "TinyTeX-1", repository = "https://mirror.math.princeton.edu")'
+    Rscript -e 'tinytex::install_tinytex(version = "2026.04", bundle = "TinyTeX-1", repository = "https://mirror.math.princeton.edu/pub/CTAN")'
 
 # Needed for summarytools namespace
 RUN Rscript -e 'install.packages("tcltk")'

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update \
 
 # Install tinytex
 RUN Rscript -e 'devtools::install_version("tinytex", version="0.59", repos="https://cloud.r-project.org")' && \
-    Rscript -e 'tinytex::install_tinytex(version = "2026.04", bundle = "TinyTeX-1")'
+    Rscript -e 'tinytex::install_tinytex(version = "2026.04", bundle = "TinyTeX-1", repository = "https://mirror.math.princeton.edu")'
 
 # Needed for summarytools namespace
 RUN Rscript -e 'install.packages("tcltk")'

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update \
 
 # Install tinytex
 RUN Rscript -e 'devtools::install_version("tinytex", version="0.59", repos="https://cloud.r-project.org")' && \
-    Rscript -e 'tinytex::install_tinytex(version = "2026.04", bundle = "TinyTeX-1")'
+    Rscript -e 'tinytex::install_tinytex(version = "2026.05", bundle = "TinyTeX-1")'
 
 # Needed for summarytools namespace
 RUN Rscript -e 'install.packages("tcltk")'

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update \
 
 # Install tinytex
 RUN Rscript -e 'devtools::install_version("tinytex", version="0.59", repos="https://cloud.r-project.org")' && \
-    Rscript -e 'tinytex::install_tinytex(version = "2026.05", bundle = "TinyTeX-1")'
+    Rscript -e 'tinytex::install_tinytex(version = "2026.04", bundle = "TinyTeX-1", repository = "https://tlnet.yihui.org")'
 
 # Needed for summarytools namespace
 RUN Rscript -e 'install.packages("tcltk")'

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update \
 
 # Install tinytex
 RUN Rscript -e 'devtools::install_version("tinytex", version="0.59", repos="https://cloud.r-project.org")' && \
-    Rscript -e 'tinytex::install_tinytex(version = "2026.04", bundle = "TinyTeX-1", repository = "https://tlnet.yihui.org")'
+    Rscript -e 'tinytex::install_tinytex(version = "2026.04", bundle = "TinyTeX-1")'
 
 # Needed for summarytools namespace
 RUN Rscript -e 'install.packages("tcltk")'


### PR DESCRIPTION
**Issue**
During the R Markdown → Pandoc → XeLaTeX pipeline, TinyTeX installs missing LaTeX packages on demand. Package installation may initially succeed, but the process can fail when an out-of-sync CTAN mirror is used, resulting in errors such as:
- `Remote database ... seems to be older than the local installation`
- LaTeX errors due to missing packages: `! LaTeX Error: File 'pdflscape.sty' not found.`

The failure was triggered when the configured TinyTeX repository (https://tlnet.yihui.org/systems/texlive/tlnet) became inaccessible or returned invalid responses during the Cloud Build step (e.g., HTML instead of a TeX Live package index). As a result, the system fell back to the default CTAN mirror network, which dynamically selects mirrors per request.

This issue occurred around the TinyTeX v2026.05 release (https://github.com/rstudio/tinytex-releases/releases/tag/v2026.05), but there is no clear evidence that the update caused the `tlnet.yihui.org mirror` to become inaccessible. The mirror is maintained separately, and the logs indicate fallback occurred when the configured repository could not be reached.

Cloud Build log on 5/1/2026
https://console.cloud.google.com/cloud-build/builds;region=global/1a452cd7-cafb-4ec4-83ac-3d4497434018?project=nih-nci-dceg-connect-prod-6d04
```
tlmgr option sys_bin ~/bin
tlmgr: setting option sys_bin to /root/bin.
tlmgr: updating /root/.TinyTeX/tlpkg/texlive.tlpdb
tlmgr option repository 'https://tlnet.yihui.org/systems/texlive/tlnet'
tlmgr: setting default package repository to https://tlnet.yihui.org/systems/texlive/tlnet
tlmgr: updating /root/.TinyTeX/tlpkg/texlive.tlpdb
tlmgr update --list
First directive needs to be 'name', not <!DOCTYPE html> at /root/.TinyTeX/tlpkg/TeXLive/TLPOBJ.pm line 106, <$retfh> line 1.
tlmgr option repository ctan
tlmgr: setting default package repository to https://mirror.ctan.org/systems/texlive/tlnet
tlmgr: updating /root/.TinyTeX/tlpkg/texlive.tlpdb
You may have to restart your system after installing TinyTeX to make sure ~/bin appears in your PATH variable (https://github.com/rstudio/tinytex/issues/16).
Warning message:
In tinytex::install_tinytex(version = "2026.04", bundle = "TinyTeX-1") :
  The repository https://tlnet.yihui.org does not seem to be accessible. Reverting to the default CTAN mirror.
Removing intermediate container 41d576d596c4
 ---> a189173b9782
Step 6/23 : RUN Rscript -e 'install.packages("tcltk")'
 ---> Running in c6e0759e47a2
Installing package into ‘/usr/local/lib/R/site-library’
(as ‘lib’ is unspecified)
Warning message:
package ‘tcltk’ is a base package, and should not be updated 
Removing intermediate container c6e0759e47a2
 ---> f45c561a54ac
Step 7/23 : RUN R -e "devtools::install_version('xfun', version='0.55', repos='https://cloud.r-project.org')"
 ---> Running in 1b77a2264c37
```

Cloud Run log for ccc-biospecimen-metrics on 5/4/2026
https://console.cloud.google.com/run/detail/us-central1/ccc-biospecimen-metrics/observability/logs?project=nih-nci-dceg-connect-prod-6d04
Note: Copied timestamps appear in UTC (Z), while the Cloud console displays them in EDT.
```
DEFAULT 2026-05-04T15:53:08.985634Z /usr/local/bin/pandoc +RTS -K512m -RTS Weekly_Biospecimen_Metrics.knit.md --to latex --from markdown+autolink_bare_uris+tex_math_single_backslash --output Weekly_Biospecimen_Metrics_05_04_2026_boxfolder_204235111776.tex --lua-filter /usr/local/lib/R/site-library/rmarkdown/rmarkdown/lua/pagebreak.lua --lua-filter /usr/local/lib/R/site-library/rmarkdown/rmarkdown/lua/latex-div.lua --embed-resources --standalone --table-of-contents --toc-depth 2 --highlight-style tango --pdf-engine xelatex --variable graphics --include-in-header /tmp/RtmphrjTWw/rmarkdown-str12364fadd.html --variable 'geometry:margin=1in' --include-in-header /tmp/RtmphrjTWw/rmarkdown-str12eb707b8.html
DEFAULT 2026-05-04T15:54:08.436060Z tlmgr: package repository https://mirrors.ibiblio.org/pub/mirrors/CTAN/systems/texlive/tlnet (not verified: gpg unavailable)
DEFAULT 2026-05-04T15:54:08.436097Z [1/1, ??:??/??:??] install: caption [61k]
DEFAULT 2026-05-04T15:54:08.759700Z running mktexlsr ...
DEFAULT 2026-05-04T15:54:08.943320Z done running mktexlsr.
DEFAULT 2026-05-04T15:54:08.982144Z tlmgr: package log updated: /root/.TinyTeX/texmf-var/web2c/tlmgr.log
DEFAULT 2026-05-04T15:54:08.982170Z tlmgr: command log updated: /root/.TinyTeX/texmf-var/web2c/tlmgr-commands.log
DEFAULT 2026-05-04T15:54:21.849960Z tlmgr: package repository https://mirrors.rit.edu/CTAN/systems/texlive/tlnet (not verified: gpg unavailable)
DEFAULT 2026-05-04T15:54:21.849980Z [1/1, ??:??/??:??] install: placeins [3k]
DEFAULT 2026-05-04T15:54:22.032519Z running mktexlsr ...
DEFAULT 2026-05-04T15:54:22.238277Z done running mktexlsr.
DEFAULT 2026-05-04T15:54:22.280410Z tlmgr: package log updated: /root/.TinyTeX/texmf-var/web2c/tlmgr.log
DEFAULT 2026-05-04T15:54:22.280429Z tlmgr: command log updated: /root/.TinyTeX/texmf-var/web2c/tlmgr-commands.log
DEFAULT 2026-05-04T15:54:34.683058Z tlmgr: Remote database at https://mirrors.mit.edu/CTAN/systems/texlive/tlnet
DEFAULT 2026-05-04T15:54:34.683096Z (revision 78878 of the texlive-scripts package)
DEFAULT 2026-05-04T15:54:34.683102Z seems to be older than the local installation
DEFAULT 2026-05-04T15:54:34.683108Z (revision 78893 of texlive-scripts);
DEFAULT 2026-05-04T15:54:34.683122Z please use a different mirror and/or wait a day or two.
DEFAULT 2026-05-04T15:54:34.716291Z Warning in system2("tlmgr", args, ...) :
DEFAULT 2026-05-04T15:54:34.716314Z running command ''tlmgr' search --file --global '/pdflscape.sty'' had status 1
DEFAULT 2026-05-04T15:54:34.742014Z ! LaTeX Error: File `pdflscape.sty' not found.
DEFAULT 2026-05-04T15:54:34.742035Z ! Emergency stop.
DEFAULT 2026-05-04T15:54:34.742039Z <read *>
DEFAULT 2026-05-04T15:54:34.742484Z <simpleError: LaTeX failed to compile Weekly_Biospecimen_Metrics_05_04_2026_boxfolder_204235111776.tex. See https://yihui.org/tinytex/r/#debugging for debugging tips. See Weekly_Biospecimen_Metrics_05_04_2026_boxfolder_204235111776.log for more info.>

```

**Root cause**
The failure was caused by the configured TinyTeX repository https://tlnet.yihui.org/systems/texlive/tlnet becoming inaccessible after ~4/30/2026. This caused TinyTeX to fall back to the default CTAN mirror network (https://mirror.ctan.org/), which dynamically selects mirrors per request.

**Behavior After Fallback**
- TinyTeX does not pin to a single mirror and may switch mirrors between requests
- CTAN mirrors are not perfectly synchronized and can lag behind each other

In this run:
- Package installs succeeded using available mirrors
- A subsequent request used mirrors.mit.edu, which was out of sync (older than the local TeX Live revision)
- Because of this, tlmgr could not reliably resolve or install required packages (e.g., pdflscape) and/or complete update operations
- This resulted in LaTeX compilation failure due to missing packages

**Configuration Context**
In the Cloud Build configuration, TinyTeX was configured to use the partial CTAN mirror described here: https://yihui.org/en/2026/03/tinytex-ctan-mirror/

Configured repository:
https://tlnet.yihui.org/systems/texlive/tlnet

The last successful access to this repository was during the 4/30/2026 Cloud Build:
https://console.cloud.google.com/cloud-build/builds;region=global/8b9c063b-5c39-406f-b3a5-6b2882f112f3?project=nih-nci-dceg-connect-prod-6d04

After this point, the repository became inaccessible, and the system reverted to the default CTAN mirror network.

**Fix**
Pin TinyTeX to a single, reliable CTAN mirror instead of relying on dynamic mirror selection.

In the Dockerfile, `install_tinytex()` was updated to use a fixed repository from the CTAN mirror list:
https://ctan.org/mirrors/

The Princeton, NJ mirror was selected for geographical proximity to the NCI:
https://ctan.math.princeton.edu

This avoids cross-mirror inconsistencies and prevents any steps from hitting an out-of-sync repository during a single run.

Note: CTAN mirrors are not perfectly synchronized, so this mirror may also become temporarily out of sync in the future. However, pinning ensures consistency within a given build and avoids failures caused by switching between mirrors.

Reference:
https://github.com/rstudio/tinytex/issues/450