### PR TITLE
Add dict as an argument to the ConnectFunctions function calls

### DIFF
--- a/BU Clinical Survey Summary Statistics.Rmd
+++ b/BU Clinical Survey Summary Statistics.Rmd
@@ -110,7 +110,7 @@ cat("Particiapnts with Blood, Urine Survey Completed: ", dim(BU)[[1]])
 ```{r functions, include=FALSE}
 ##FUNCTIONS
 
-dict <- list("104430631"="No", "353358909"="Yes", "178420302"="Do not Know", "536341288"="Female", "576796184"="Unknown", "654207589"="Male",
+master_dict <- list("104430631"="No", "353358909"="Yes", "178420302"="Do not Know", "536341288"="Female", "576796184"="Unknown", "654207589"="Male",
                  "110092955"="The same day", "952212668"="The day before", "330461666"="More than a day before", "974230748"="Yes, in the past day",
                  "936042740"="Yes, in the past two days", "731141335"="Yes, in the past week", "591670915"="Yes, in the past month", "111520945"="Not at all",
                  "548628123"="A little bit", "567908725"="Somewhat", "760969884"="Quite a bit", "464631026"="Very Much", "707601969"="Yes, another",

--- a/BU Clinical Survey Summary Statistics.Rmd
+++ b/BU Clinical Survey Summary Statistics.Rmd
@@ -110,7 +110,7 @@ cat("Particiapnts with Blood, Urine Survey Completed: ", dim(BU)[[1]])
 ```{r functions, include=FALSE}
 ##FUNCTIONS
 
-master_dict <- list("104430631"="No", "353358909"="Yes", "178420302"="Do not Know", "536341288"="Female", "576796184"="Unknown", "654207589"="Male",
+dict <- list("104430631"="No", "353358909"="Yes", "178420302"="Do not Know", "536341288"="Female", "576796184"="Unknown", "654207589"="Male",
                  "110092955"="The same day", "952212668"="The day before", "330461666"="More than a day before", "974230748"="Yes, in the past day",
                  "936042740"="Yes, in the past two days", "731141335"="Yes, in the past week", "591670915"="Yes, in the past month", "111520945"="Not at all",
                  "548628123"="A little bit", "567908725"="Somewhat", "760969884"="Quite a bit", "464631026"="Very Much", "707601969"="Yes, another",
@@ -139,7 +139,7 @@ master_dict <- list("104430631"="No", "353358909"="Yes", "178420302"="Do not Kno
 
 
 #SEX
-simple_funct(BU_tib,D_522008539, "SEX: Biological Sex at Birth")
+simple_funct(BU_tib,D_522008539, "SEX: Biological Sex at Birth", dict = dict)
 
 
 
@@ -183,13 +183,14 @@ dt_SYMPTDAY_long <- dt_SYMPTDAY_flags %>%
   )
 
 
-simple_funct(dt_SYMPTDAY_long, symptom_flag, "Table 2: Symptoms in the 24 hours Prior to Sample Donation") %>%
+simple_funct(dt_SYMPTDAY_long, symptom_flag, "Table 2: Symptoms in the 24 hours Prior to Sample Donation", dict = dict) %>%
   create_SATA_footnote()
 
 
 #EATDRINKBEFORE
 simple_funct(BU_tib,D_867307558, "Table 3: When Last Food or Beverage Consumed",
-factor_levels = c("The same day","The day before","More than a day before") )
+factor_levels = c("The same day","The day before","More than a day before"),
+dict = dict)
 
 
 
@@ -316,13 +317,16 @@ add_footnote(bm_wake,"Note: Those who did not answer this question are removed f
 ```{r Meds, warning=FALSE, echo=FALSE,  message=FALSE}
 
 simple_funct(BU_tib,D_487532606_D_619765650, "TYLENOL: Medication Taken, if so, Last Time Taken",
-factor_levels = c("Yes, in the past day", "Yes, in the past two days", "Yes, in the past week", "Yes, in the past month", "No") )
+factor_levels = c("Yes, in the past day", "Yes, in the past two days", "Yes, in the past week", "Yes, in the past month", "No"),
+dict = dict)
 
 simple_funct(BU_tib,D_487532606_D_520755310, "NSAIDS: Medication Taken, if so, Last Time Taken",
-factor_levels = c("Yes, in the past day", "Yes, in the past two days", "Yes, in the past week", "Yes, in the past month", "No") )
+factor_levels = c("Yes, in the past day", "Yes, in the past two days", "Yes, in the past week", "Yes, in the past month", "No"),
+dict = dict)
 
 simple_funct(BU_tib,D_487532606_D_839329467, "Acid Reducers: Medication Taken, if so, Last Time Taken",
-factor_levels = c("Yes, in the past day", "Yes, in the past two days", "Yes, in the past week", "Yes, in the past month", "No") )
+factor_levels = c("Yes, in the past day", "Yes, in the past two days", "Yes, in the past week", "Yes, in the past month", "No"),
+dict = dict)
 
 
 ```
@@ -335,12 +339,14 @@ factor_levels = c("Yes, in the past day", "Yes, in the past two days", "Yes, in 
 #MENSTPRD
 one_logic_funct(BU_tib,D_380603392, D_522008539,'536341288',
                 "MENSTPRD: Had Menstrual Period in the Last 12 Months",
-                   factor_levels = c("Yes", "No") )
+                   factor_levels = c("Yes", "No"),
+                   dict = dict)
 
 
 #MENST60
 one_logic_funct(BU_tib,D_112151599, D_380603392, "353358909", "MENST60: Had Menstrual Period in the Last 60 Days",
-                   factor_levels = c("Yes", "No") )
+                   factor_levels = c("Yes", "No"),
+                   dict = dict)
 
 
 
@@ -360,26 +366,32 @@ pM + scale_x_date(date_labels = "%b %Y")
 
 #PREGNANT
 one_logic_funct(BU_tib,D_518916981, D_522008539,'536341288',"PREGNANT: Currently Pregnant",
-                   factor_levels = c("Yes", "No") )
+                   factor_levels = c("Yes", "No"),
+                   dict = dict)
 
 #PREG3MON
 one_logic_funct(BU_tib,D_234714655, D_518916981, "104430631", "Table 13: Been Pregnant in the Last 3 Months",
-                   factor_levels = c("Yes", "No") )
+                   factor_levels = c("Yes", "No"),
+                   dict = dict)
 
 #BRSTFD
 one_logic_funct(BU_tib,D_798452445, D_522008539,'536341288',"Table 14: Currently Breastfeeding",
-                   factor_levels = c("Yes", "No") )
+                   factor_levels = c("Yes", "No"),
+                   dict = dict)
 
 #BRSTFD3MON
 one_logic_funct(BU_tib,D_563539159, D_798452445, "104430631", "Table 15: Breastfed in the Last 3 Months",
-                   factor_levels = c("Yes", "No") )
+                   factor_levels = c("Yes", "No"),
+                   dict = dict)
 
 #CONTRACEPT
 one_logic_funct(BU_tib,D_875535246, D_518916981, "104430631", "Table 16: Used Hormonal Contraceptives in the Last Month",
-                   factor_levels = c("Yes", "No") )
+                   factor_levels = c("Yes", "No"),
+                   dict = dict)
 
 #HORMONE
 one_logic_funct(BU_tib,D_130311122, D_518916981, "104430631", "Table 17: Used Prescription Hormone Therapy in the Last Month",
-                   factor_levels = c("Yes", "No") )
+                   factor_levels = c("Yes", "No"),
+                   dict = dict)
 
 ```

--- a/BU Clinical Survey Summary Statistics.Rmd
+++ b/BU Clinical Survey Summary Statistics.Rmd
@@ -139,7 +139,7 @@ dict <- list("104430631"="No", "353358909"="Yes", "178420302"="Do not Know", "53
 
 
 #SEX
-simple_funct(BU_tib,D_522008539, "SEX: Biological Sex at Birth")
+simple_funct(BU_tib,D_522008539, "SEX: Biological Sex at Birth", dict = dict)
 
 
 
@@ -183,13 +183,14 @@ dt_SYMPTDAY_long <- dt_SYMPTDAY_flags %>%
   )
 
 
-simple_funct(dt_SYMPTDAY_long, symptom_flag, "Table 2: Symptoms in the 24 hours Prior to Sample Donation") %>% 
+simple_funct(dt_SYMPTDAY_long, symptom_flag, "Table 2: Symptoms in the 24 hours Prior to Sample Donation", dict = dict) %>%
   create_SATA_footnote()
 
 
 #EATDRINKBEFORE
 simple_funct(BU_tib,D_867307558, "Table 3: When Last Food or Beverage Consumed",
-factor_levels = c("The same day","The day before","More than a day before") )
+factor_levels = c("The same day","The day before","More than a day before"),
+dict = dict)
 
 
 
@@ -316,13 +317,16 @@ add_footnote(bm_wake,"Note: Those who did not answer this question are removed f
 ```{r Meds, warning=FALSE, echo=FALSE,  message=FALSE}
 
 simple_funct(BU_tib,D_487532606_D_619765650, "TYLENOL: Medication Taken, if so, Last Time Taken",
-factor_levels = c("Yes, in the past day", "Yes, in the past two days", "Yes, in the past week", "Yes, in the past month", "No") )
+factor_levels = c("Yes, in the past day", "Yes, in the past two days", "Yes, in the past week", "Yes, in the past month", "No"),
+dict = dict)
 
 simple_funct(BU_tib,D_487532606_D_520755310, "NSAIDS: Medication Taken, if so, Last Time Taken",
-factor_levels = c("Yes, in the past day", "Yes, in the past two days", "Yes, in the past week", "Yes, in the past month", "No") )
+factor_levels = c("Yes, in the past day", "Yes, in the past two days", "Yes, in the past week", "Yes, in the past month", "No"),
+dict = dict)
 
 simple_funct(BU_tib,D_487532606_D_839329467, "Acid Reducers: Medication Taken, if so, Last Time Taken",
-factor_levels = c("Yes, in the past day", "Yes, in the past two days", "Yes, in the past week", "Yes, in the past month", "No") )
+factor_levels = c("Yes, in the past day", "Yes, in the past two days", "Yes, in the past week", "Yes, in the past month", "No"),
+dict = dict)
 
 
 ```
@@ -335,12 +339,14 @@ factor_levels = c("Yes, in the past day", "Yes, in the past two days", "Yes, in 
 #MENSTPRD
 one_logic_funct(BU_tib,D_380603392, D_522008539,'536341288',
                 "MENSTPRD: Had Menstrual Period in the Last 12 Months",
-                   factor_levels = c("Yes", "No"))
+                   factor_levels = c("Yes", "No"),
+                   dict = dict)
 
 
 #MENST60
 one_logic_funct(BU_tib,D_112151599, D_380603392, "353358909", "MENST60: Had Menstrual Period in the Last 60 Days",
-                   factor_levels = c("Yes", "No")) 
+                   factor_levels = c("Yes", "No"),
+                   dict = dict)
 
 
 
@@ -360,26 +366,32 @@ pM + scale_x_date(date_labels = "%b %Y")
 
 #PREGNANT
 one_logic_funct(BU_tib,D_518916981, D_522008539,'536341288',"PREGNANT: Currently Pregnant",
-                   factor_levels = c("Yes", "No"))
+                   factor_levels = c("Yes", "No"),
+                   dict = dict)
 
 #PREG3MON
 one_logic_funct(BU_tib,D_234714655, D_518916981, "104430631", "Table 13: Been Pregnant in the Last 3 Months",
-                   factor_levels = c("Yes", "No")) 
+                   factor_levels = c("Yes", "No"),
+                   dict = dict)
 
 #BRSTFD
 one_logic_funct(BU_tib,D_798452445, D_522008539,'536341288',"Table 14: Currently Breastfeeding",
-                   factor_levels = c("Yes", "No"))
+                   factor_levels = c("Yes", "No"),
+                   dict = dict)
 
 #BRSTFD3MON
 one_logic_funct(BU_tib,D_563539159, D_798452445, "104430631", "Table 15: Breastfed in the Last 3 Months",
-                   factor_levels = c("Yes", "No")) 
+                   factor_levels = c("Yes", "No"),
+                   dict = dict)
 
 #CONTRACEPT
 one_logic_funct(BU_tib,D_875535246, D_518916981, "104430631", "Table 16: Used Hormonal Contraceptives in the Last Month",
-                   factor_levels = c("Yes", "No")) 
+                   factor_levels = c("Yes", "No"),
+                   dict = dict)
 
 #HORMONE
 one_logic_funct(BU_tib,D_130311122, D_518916981, "104430631", "Table 17: Used Prescription Hormone Therapy in the Last Month",
-                   factor_levels = c("Yes", "No")) 
+                   factor_levels = c("Yes", "No"),
+                   dict = dict)
 
 ```

--- a/BU Clinical Survey Summary Statistics.Rmd
+++ b/BU Clinical Survey Summary Statistics.Rmd
@@ -139,7 +139,7 @@ master_dict <- list("104430631"="No", "353358909"="Yes", "178420302"="Do not Kno
 
 
 #SEX
-simple_funct(BU_tib,D_522008539, "SEX: Biological Sex at Birth", dict = dict)
+simple_funct(BU_tib,D_522008539, "SEX: Biological Sex at Birth")
 
 
 
@@ -189,8 +189,7 @@ simple_funct(dt_SYMPTDAY_long, symptom_flag, "Table 2: Symptoms in the 24 hours 
 
 #EATDRINKBEFORE
 simple_funct(BU_tib,D_867307558, "Table 3: When Last Food or Beverage Consumed",
-factor_levels = c("The same day","The day before","More than a day before"),
-dict = dict)
+factor_levels = c("The same day","The day before","More than a day before") )
 
 
 
@@ -317,16 +316,13 @@ add_footnote(bm_wake,"Note: Those who did not answer this question are removed f
 ```{r Meds, warning=FALSE, echo=FALSE,  message=FALSE}
 
 simple_funct(BU_tib,D_487532606_D_619765650, "TYLENOL: Medication Taken, if so, Last Time Taken",
-factor_levels = c("Yes, in the past day", "Yes, in the past two days", "Yes, in the past week", "Yes, in the past month", "No"),
-dict = dict)
+factor_levels = c("Yes, in the past day", "Yes, in the past two days", "Yes, in the past week", "Yes, in the past month", "No") )
 
 simple_funct(BU_tib,D_487532606_D_520755310, "NSAIDS: Medication Taken, if so, Last Time Taken",
-factor_levels = c("Yes, in the past day", "Yes, in the past two days", "Yes, in the past week", "Yes, in the past month", "No"),
-dict = dict)
+factor_levels = c("Yes, in the past day", "Yes, in the past two days", "Yes, in the past week", "Yes, in the past month", "No") )
 
 simple_funct(BU_tib,D_487532606_D_839329467, "Acid Reducers: Medication Taken, if so, Last Time Taken",
-factor_levels = c("Yes, in the past day", "Yes, in the past two days", "Yes, in the past week", "Yes, in the past month", "No"),
-dict = dict)
+factor_levels = c("Yes, in the past day", "Yes, in the past two days", "Yes, in the past week", "Yes, in the past month", "No") )
 
 
 ```
@@ -339,14 +335,12 @@ dict = dict)
 #MENSTPRD
 one_logic_funct(BU_tib,D_380603392, D_522008539,'536341288',
                 "MENSTPRD: Had Menstrual Period in the Last 12 Months",
-                   factor_levels = c("Yes", "No"),
-                   dict = dict)
+                   factor_levels = c("Yes", "No") )
 
 
 #MENST60
 one_logic_funct(BU_tib,D_112151599, D_380603392, "353358909", "MENST60: Had Menstrual Period in the Last 60 Days",
-                   factor_levels = c("Yes", "No"),
-                   dict = dict)
+                   factor_levels = c("Yes", "No") )
 
 
 
@@ -366,32 +360,26 @@ pM + scale_x_date(date_labels = "%b %Y")
 
 #PREGNANT
 one_logic_funct(BU_tib,D_518916981, D_522008539,'536341288',"PREGNANT: Currently Pregnant",
-                   factor_levels = c("Yes", "No"),
-                   dict = dict)
+                   factor_levels = c("Yes", "No") )
 
 #PREG3MON
 one_logic_funct(BU_tib,D_234714655, D_518916981, "104430631", "Table 13: Been Pregnant in the Last 3 Months",
-                   factor_levels = c("Yes", "No"),
-                   dict = dict)
+                   factor_levels = c("Yes", "No") )
 
 #BRSTFD
 one_logic_funct(BU_tib,D_798452445, D_522008539,'536341288',"Table 14: Currently Breastfeeding",
-                   factor_levels = c("Yes", "No"),
-                   dict = dict)
+                   factor_levels = c("Yes", "No") )
 
 #BRSTFD3MON
 one_logic_funct(BU_tib,D_563539159, D_798452445, "104430631", "Table 15: Breastfed in the Last 3 Months",
-                   factor_levels = c("Yes", "No"),
-                   dict = dict)
+                   factor_levels = c("Yes", "No") )
 
 #CONTRACEPT
 one_logic_funct(BU_tib,D_875535246, D_518916981, "104430631", "Table 16: Used Hormonal Contraceptives in the Last Month",
-                   factor_levels = c("Yes", "No"),
-                   dict = dict)
+                   factor_levels = c("Yes", "No") )
 
 #HORMONE
 one_logic_funct(BU_tib,D_130311122, D_518916981, "104430631", "Table 17: Used Prescription Hormone Therapy in the Last Month",
-                   factor_levels = c("Yes", "No"),
-                   dict = dict)
+                   factor_levels = c("Yes", "No") )
 
 ```

--- a/BU Clinical Survey Summary Statistics.Rmd
+++ b/BU Clinical Survey Summary Statistics.Rmd
@@ -183,7 +183,7 @@ dt_SYMPTDAY_long <- dt_SYMPTDAY_flags %>%
   )
 
 
-simple_funct(dt_SYMPTDAY_long, symptom_flag, "Table 2: Symptoms in the 24 hours Prior to Sample Donation", dict = dict) %>%
+simple_funct(dt_SYMPTDAY_long, symptom_flag, "Table 2: Symptoms in the 24 hours Prior to Sample Donation") %>%
   create_SATA_footnote()
 
 


### PR DESCRIPTION
**Issue**
This current pull request only addresses one affected file `BU Clinical Survey Summary Statistics.Rmd`; However, other reports, including `Merged Module 2 Summary Statistics.Rmd` in `ccc_module_metrics_gcp_pipeline`, are affected by the same underlying issue.

The `ccc_biospecimen_metrics_api.R` and `ccc_module_metrics_api.R` Plumber service renders report Rmd files via:
`rmarkdown::render(r_file_name, envir = new.env())`

When rendering `BU Clinical Survey Summary Statistics.Rmd` or `Merged Module 2 Summary Statistics.Rmd` through this API, the render fails partway through, despite `dict` being created successfully earlier in each Rmd's functions chunk. The same reports render without error when knitted interactively in RStudio, which delayed detection of the bug until it reached the automated pipeline.

`BU Clinical Survey Summary Statistics.Rmd` in `ccc_biospecimen_metrics_gcp_pipeline` Cloud Run service log error
```
2026-08-03 15:02:19.274 EDT https://ccc-biospecimen-metrics-xbxy4luxeq-uc.a.run.app/run-biospecimen-metrics?report=bum_research_survey_stats&testing=false
...
2026-08-03 15:02:36.631 EDT 10/23 [Tables1_3]  
2026-08-03 15:02:36.667 EDT <simpleError in handler(loc): argument "loc" is missing, with no default>
```
`Merged Module 2 Summary Statistics.Rmd` in `ccc_module_metrics_gcp_pipeline` Cloud Run service log error
```
2026-08-03 16:10:33.162 EDT https://ccc-module-metrics-api-xbxy4luxeq-uc.a.run.app/run-module-metrics?report=mod2_stats&testing=false
...
2026-08-03 16:11:31.705 EDT 16/149 [PainMedsTable]
2026-08-03 16:11:38.290 EDT Quitting from Merged-Module-2-Summary-Statistics.Rmd:429-469 [PainMedsTable]
2026-08-03 16:11:38.291 EDT [1] "Rendering failed with error:  object 'dict' not found"
```

**Root cause**
`dict` is a named lookup list created locally inside each Rmd's own environment. However, the functions that consume it (`simple_funct()`, `one_logic_funct()`, `two_logic_funct()`, `three_logic_funct()`, `four_logic_funct()`, and `five_logic_funct()`) are defined in the separately installed `ConnectFunctions` package, not in the Rmd itself. Internally these functions reference `dict` via:
`mutate(answer = dplyr::recode(!!CID_SYM, !!!dict))
`
without `dict` ever being passed in as an argument, relying instead on R's scoping rules to find `dict` in the caller's environment.
- Interactively in RStudio: `dict` lives in `.GlobalEnv`, which these package functions could reach, so the lookup silently succeeded.
- Under `rmarkdown::render(envir = new.env())`: the entire Rmd, including `dict`, executes inside a freshly created, isolated environment that is not `.GlobalEnv`. `ConnectFunctions`'s functions have no way to see into that isolated environment, so the `dict` lookup fails.

This is why the bug was invisible locally and only appeared once the exact same isolated-environment render was reproduced (`rmarkdown::render(..., envir = new.env())` run from a clean R session).

**Fix**
1. `ConnectFunctions` package (`R/` source): Added `dict` as an explicit parameter to the six affected functions in this [commit](https://github.com/Analyticsphere/ConnectFunctions/commit/ff3eaad00032b035dc083aee2063d4116e2a86c3).
2. BU Clinical Survey Summary Statistics.Rmd: Updated every call to the six affected functions to pass `dict = dict` explicitly.


**Future Fixes Needed**
1. Any functions in `ConnectFunctions` that reference a `dict` created outside the package needs `dict` added as an explicit parameter.
2. Any call to a `ConnectFunctions` function in a report Rmd file that relies on `dict` needs to pass `dict` as an explicit argument, across all repos, including:
- [ccc_biospecimen_metrics_gcp_pipeline](https://github.com/Analyticsphere/ccc_biospecimen_metrics_gcp_pipeline/tree/c05aa771d0c0b75ecfffd1027b39e3f91121686f)
- [ccc_module_metrics_gcp_pipeline](https://github.com/Analyticsphere/ccc_module_metrics_gcp_pipeline)